### PR TITLE
GenerateCommonAssemblyInfoTask should use BuildProps.ProductVersionFieldCount

### DIFF
--- a/FlubuCore/Tasks/Versioning/GenerateCommonAssemblyInfoTask.cs
+++ b/FlubuCore/Tasks/Versioning/GenerateCommonAssemblyInfoTask.cs
@@ -16,7 +16,7 @@ namespace FlubuCore.Tasks.Versioning
         private string _buildConfiguration;
         private bool _generateConfigurationAttribute;
         private bool _generateCultureAttribute;
-        private int _productVersionFieldCount = 2;
+        private int _productVersionFieldCount;
         private string _informationalVersion;
         private Version _buildVersion;
         private string _description;
@@ -32,17 +32,8 @@ namespace FlubuCore.Tasks.Versioning
 
         protected override string Description
         {
-            get
-            {
-                if (string.IsNullOrEmpty(_description))
-                {
-                    return $"Generates common assembly info file.";
-                }
-
-                return _description;
-            }
-
-            set { _description = value; }
+            get => string.IsNullOrEmpty(_description) ? "Generates common assembly info file." : _description;
+            set => _description = value;
         }
 
         public GenerateCommonAssemblyInfoTask BuildVersion(Version buildVersion)


### PR DESCRIPTION
Field `_productVersionFieldCount` in task `GenerateCommonAssemblyInfoTask ` should not have a default value. Otherwise `BuildProps.ProductVersionFieldCount` is [never used](https://github.com/jenzy/flubu.core/blob/5ecf9a4fcad4ee9b83a14770ec3351ffd9f2bc58/FlubuCore/Tasks/Versioning/GenerateCommonAssemblyInfoTask.cs#L144-L145). The default value is already specified when getting `BuildProps.ProductVersionFieldCount`.