### PR TITLE
Flubu.Runner Buildscript.cs conflict

### DIFF
--- a/Nuget/FlubuCoreRunner.nuspec
+++ b/Nuget/FlubuCoreRunner.nuspec
@@ -10,25 +10,25 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <licenseUrl>http://www.opensource.org/licenses/bsd-license.php</licenseUrl>
     <description>
-	  This package includes the Flubu runner which is used for executing Flubu scripts. 
+    This package includes the Flubu runner which is used for executing Flubu scripts. 
       Flubu is a C# library for building projects and executing deployment scripts using C# code.
       Wiki can be found at: https://github.com/flubu-core/flubu.core/wiki
       A detailed example of how Flubu is used to build example project: https://github.com/flubu-core/examples
     </description>
      <tags>build builder script buildscript automation VisualStudio</tags>  
-	<references>
-		<reference file="FlubuCore.dll" />
-	</references>
+  <references>
+    <reference file="FlubuCore.dll" />
+  </references>
   </metadata>
   <files>
     <file src="..\output\FlubuCore.dll" target="lib" />
     <file src="..\output\FlubuCore.pdb" target="lib" />
-	<file src="..\output\FlubuCore.xml" target="lib" />
+    <file src="..\output\FlubuCore.xml" target="lib" />
     <file src="..\output\FlubuCore.dll" target="content\temp" /> 
     <file src="..\output\Build.exe" target="content\temp" />
-	<file src="..\output\Build.exe.config" target="content\temp" />
-    <file src="..\FlubuCore\BuildScript.cs" target="content" /> 
-	<file src="..\nuget\tools\Install.ps1" target="tools\Install.ps1" />
+    <file src="..\output\Build.exe.config" target="content\temp" />
+    <file src="..\FlubuCore\BuildScript.cs" target="content\temp" /> 
+    <file src="..\nuget\tools\Install.ps1" target="tools\Install.ps1" />
     <file src="..\Nuget\readme.txt" target="" /> 
   </files>
 </package>


### PR DESCRIPTION
BuildScript.cs is moved to the temp directory (with .nuspec) and later added to the project with install.ps1 - if it doesn't already exist in target project.

Resolves #20.

Inspired by https://stackoverflow.com/questions/26917278/is-there-a-way-to-tell-nuget-to-install-a-file-into-a-project-only-if-the-file.