### PR TITLE
RunProgramTask: fix switched stdout and stderr

### DIFF
--- a/Flubu.Tests/Tasks/RunProgramTaskTests.cs
+++ b/Flubu.Tests/Tasks/RunProgramTaskTests.cs
@@ -115,5 +115,47 @@ namespace Flubu.Tests.Tasks
                 .WorkingFolder("test")
                 .ExecuteVoid(Context);
         }
+
+        [Fact]
+        public void CaptureOutput()
+        {
+            Action<string> onOutput = null, onError = null;
+
+            _commandFactory.Setup(i => i.Create("dotnet", new List<string>(), null, "Debug")).Returns(_command.Object);
+
+            _command.Setup(i => i.CaptureStdErr()).Returns(_command.Object);
+            _command.Setup(i => i.CaptureStdOut()).Returns(_command.Object);
+            _command.Setup(i => i.WorkingDirectory(It.IsAny<string>())).Returns(_command.Object);
+            _command.Setup(i => i.OnErrorLine(It.IsAny<Action<string>>())).Returns(_command.Object);
+            _command.Setup(i => i.OnOutputLine(It.IsAny<Action<string>>())).Returns(_command.Object);
+            _command.Setup(i => i.Execute()).Returns(new CommandResult(new ProcessStartInfo { Arguments = "aa" }, 0, string.Empty, string.Empty));
+
+            _command.Setup(i => i.OnOutputLine(It.IsAny<Action<string>>()))
+                    .Callback<Action<string>>(action => onOutput = action)
+                    .Returns(_command.Object);
+
+            _command.Setup(i => i.OnErrorLine(It.IsAny<Action<string>>()))
+                    .Callback<Action<string>>(action => onError = action)
+                    .Returns(_command.Object);
+
+            var task = new RunProgramTask(_commandFactory.Object, "dotnet");
+
+            int res = task.CaptureOutput()
+                          .CaptureErrorOutput()
+                          .DoNotLogOutput()
+                          .Execute(Context);
+
+            onOutput?.Invoke("output line 1");
+            onOutput?.Invoke("output line 2");
+            onError?.Invoke("error line 1");
+            onError?.Invoke("error line 2");
+
+            string output = task.GetOutput()?.Replace("\r", string.Empty)?.Replace("\n", string.Empty);
+            string outputError = task.GetErrorOutput()?.Replace("\r", string.Empty)?.Replace("\n", string.Empty);
+
+            Assert.Equal(0, res);
+            Assert.Equal("output line 1output line 2", output);
+            Assert.Equal("error line 1error line 2", outputError);
+        }
     }
 }

--- a/FlubuCore/Tasks/Process/RunProgramTask.cs
+++ b/FlubuCore/Tasks/Process/RunProgramTask.cs
@@ -146,7 +146,7 @@ namespace FlubuCore.Tasks.Process
                         DoLogInfo(l);
 
                     if (_captureOutput)
-                        _output.AppendLine(l);
+                        _errorOutput.AppendLine(l);
                 })
                 .OnOutputLine(l =>
                 {
@@ -154,7 +154,7 @@ namespace FlubuCore.Tasks.Process
                         DoLogInfo(l);
 
                     if (_captureErrorOutput)
-                        _errorOutput.AppendLine(l);
+                        _output.AppendLine(l);
                 });
 
             DoLogInfo(


### PR DESCRIPTION
Before the fix `task.GetOutput()` returned stderr and vice-versa.