### PR TITLE
Expose the output of ExternalProcessTaskBase

### DIFF
--- a/FlubuCore.Tests/Tasks/RunProgramTaskTests.cs
+++ b/FlubuCore.Tests/Tasks/RunProgramTaskTests.cs
@@ -25,26 +25,6 @@ namespace FlubuCore.Tests.Tasks
         }
 
         [Fact]
-        public void QuickTest()
-        {
-           var a = TestTer<int>();
-        }
-
-        public T TestTer<T>()
-        {
-            int i = 5;
-            T a;
-
-            if (typeof(T) == typeof(int))
-            {
-                a = (T)(object)i;
-                return a;
-            }
-
-            return default(T);
-        }
-
-        [Fact]
         public void ExecuteDotNetCommandWithFullPath()
         {
             var fileName = GetOsPlatform() == OSPlatform.Windows ? "C:\\Program Files\\dotnet\\dotnet.exe" : "/usr/bin/dotnet";

--- a/FlubuCore/Tasks/Process/IRunProgramTask.cs
+++ b/FlubuCore/Tasks/Process/IRunProgramTask.cs
@@ -1,6 +1,6 @@
 ﻿namespace FlubuCore.Tasks.Process
 {
-    /// <inheritdoc cref="ITaskOfT{T}" />
+    /// <inheritdoc cref="ITaskOfT{T, TTask}" />
     public interface IRunProgramTask : ITaskOfT<int, IRunProgramTask>, IExternalProcess<IRunProgramTask>
     {
         /// <summary>

--- a/FlubuCore/Tasks/Versioning/GitVersionTask.cs
+++ b/FlubuCore/Tasks/Versioning/GitVersionTask.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using FlubuCore.Context;
 using FlubuCore.Tasks.Process;
 using Newtonsoft.Json;
@@ -12,11 +11,10 @@ namespace FlubuCore.Tasks.Versioning
         public GitVersionTask()
         {
             ExecutablePath = "gitversion";
+            KeepProgramOutput = true;
         }
 
         protected override string Description { get; set; }
-
-        protected override bool GetProgramOutput { get; } = true;
 
         /// <summary>
         ///  The directory containing .git. If not defined current directory is used. (Must be first argument).
@@ -280,9 +278,10 @@ namespace FlubuCore.Tasks.Versioning
         {
             base.DoExecute(context);
 
-            if (!string.IsNullOrEmpty(ProgramOutput))
+            var output = GetOutput();
+            if (!string.IsNullOrEmpty(output))
             {
-                var gitVersion = JsonConvert.DeserializeObject<GitVersion>(ProgramOutput);
+                var gitVersion = JsonConvert.DeserializeObject<GitVersion>(output);
                 context.Properties.Set(BuildProps.BuildVersion, new Version(gitVersion.AssemblySemVer));
                 return gitVersion;
             }


### PR DESCRIPTION
Fixes #198.

Note that now all members of `IRunProgramTask` could be pushed up to `IExternalProcess`. As that would be  a potentially breaking change I wanted to discuss it first.